### PR TITLE
vhpidirect: add report message to canary assertions

### DIFF
--- a/vhpidirect/quickstart/customc/tb.vhd
+++ b/vhpidirect/quickstart/customc/tb.vhd
@@ -5,25 +5,25 @@ architecture arch of tb is
 
   procedure cproc is
   begin
-    assert false severity failure;
+    assert false report "VHPIDIRECT custom_procedure" severity failure;
   end;
   attribute foreign of cproc : procedure is "VHPIDIRECT custom_procedure";
 
   procedure cproc_wargs ( x: integer ) is
   begin
-    assert false severity failure;
+    assert false report "VHPIDIRECT custom_procedure_withargs" severity failure;
   end;
   attribute foreign of cproc_wargs : procedure is "VHPIDIRECT custom_procedure_withargs";
 
   function cfunc return integer is
   begin
-    assert false severity failure;
+    assert false report "VHPIDIRECT custom_function" severity failure;
   end;
   attribute foreign of cfunc : function is "VHPIDIRECT custom_function";
 
   function cfunc_wargs ( x: integer ) return integer is
   begin
-    assert false severity failure;
+    assert false report "VHPIDIRECT custom_function_withargs" severity failure;
   end;
   attribute foreign of cfunc_wargs : function is "VHPIDIRECT custom_function_withargs";
 

--- a/vhpidirect/quickstart/math/tb.vhd
+++ b/vhpidirect/quickstart/math/tb.vhd
@@ -5,7 +5,7 @@ architecture arch of tb is
 
   function sin (v : real) return real is
   begin
-    assert false severity failure;
+    assert false report "VHPIDIRECT sin" severity failure;
   end;
   attribute foreign of sin : function is "VHPIDIRECT sin";
 

--- a/vhpidirect/quickstart/random/tb.vhd
+++ b/vhpidirect/quickstart/random/tb.vhd
@@ -5,7 +5,7 @@ architecture arch of tb is
 
   function rand return integer is
   begin
-    assert false severity failure;
+    assert false report "VHPIDIRECT rand" severity failure;
   end;
   attribute foreign of rand : function is "VHPIDIRECT rand";
 

--- a/vhpidirect/shared/shlib/tb.vhd
+++ b/vhpidirect/shared/shlib/tb.vhd
@@ -5,7 +5,7 @@ architecture arch of tb is
 
   function get_rand return integer is
   begin
-    assert false severity failure;
+    assert false report "VHPIDIRECT ./lib.so get_rand" severity failure;
   end;
   attribute foreign of get_rand: function is "VHPIDIRECT ./lib.so get_rand";
 


### PR DESCRIPTION
As commented in https://github.com/umarcor/ghdl-cosim/pull/4#discussion_r407682762, this PR adds report messages to the assertions that should never be executed. If any of these is executed, it means that foreign sources have not been properly linked. Having a specific message helps understand which function is failing.