### PR TITLE
doc: update index, clean examples index

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,7 +19,13 @@ Co-simulation with GHDL
 
 .. index:: SystemC
 
-Three main approaches are used to co-simulate (co-execute) VHDL sources along with software applications written in a language other than VHDL (typically C/C++/SystemC):
+This repository contains documentation and working examples about how to co-simulate VHDL and other languages through
+GHDL's foreign interfaces. Since specific features of the language and the tool are used, it is suggested for users
+who are new to either `GHDL` or `VHDL` to first read the :ref:`USING:QuickStart` in the main documentation
+(`ghdl.rtfd.io <https://ghdl.rtfd.io>`_).
+
+Three main approaches are used to co-simulate (co-execute) VHDL sources along with software applications written in a
+language other than VHDL (typically C/C++/SystemC):
 
 * Verilog Procedural Interface (VPI), also known as Program Language Interface (PLI) 2.0.
 
@@ -28,9 +34,10 @@ Three main approaches are used to co-simulate (co-execute) VHDL sources along wi
 * Generation of C/C++ models/sources through a transpiler.
 
 VPI and VHPI are complex APIs which allow to inspect the hierarchy, set callbacks and/or assign signals. Because
-provided features are similar, GHDL supports VPI only. Furthermore, as an easier to use alternative, GHDL features a custom coexecution procedure named VHPIDIRECT, similar to SystemVerilog's Direct Programming Interface (DPI).
-As of today, generation of C/C++ models à la Verilator is not supported. However, a *ghdlator* might be available in
-the future.
+provided features are similar, GHDL supports VPI only. Furthermore, as an easier to use alternative, GHDL features a
+custom coexecution procedure named VHPIDIRECT, similar to SystemVerilog's Direct Programming Interface (DPI).
+As of today, generation of C++/SystemC models à la Verilator is not supported. However, a *vhdlator*/*ghdlator* might
+be available in the future.
 
 .. toctree::
    :caption: VHPIDIRECT
@@ -47,7 +54,9 @@ You can define a subprogram in a foreign language (such as `C` or
 `Ada`) and import it into a VHDL design.
 
 .. NOTE::
-  GHDL supports different backends, and not all of them generate binary artifacts. Precisely, ``mcode`` is an in-memory backend. Hence, the examples need to be built/executed with either LLVM or GCC backends. A few of them, the ones that do not require linking object files, can be used with mcode.
+  GHDL supports different backends, and not all of them generate binary artifacts. Precisely, ``mcode`` is an in-memory
+  backend. Hence, the examples need to be built/executed with either LLVM or GCC backends. A few of them, the ones that
+  do not require linking object files, can be used with mcode.
 
 .. ATTENTION::
   As a consequence of the runtime copyright, you are not allowed to distribute an

--- a/doc/vhpidirect/examples/index.rst
+++ b/doc/vhpidirect/examples/index.rst
@@ -3,13 +3,6 @@
 Examples
 ########
 
-.. IMPORTANT::
-   It is suggested for users who are new to either
-  `GHDL` or `VHDL` to read :ref:`USING:QuickStart` first.
-
-This sections contains advanced examples using specific features of the language, the tool,
-or interaction with third-party projects.
-
 .. toctree::
 
    quickstart

--- a/doc/vpi/examples/index.rst
+++ b/doc/vpi/examples/index.rst
@@ -1,9 +1,4 @@
 Examples
 ########
 
-.. IMPORTANT::
-  This sections contains advanced examples using specific features of the language, the tool,
-  or interaction with third-party projects. It is suggested for users who are new to either
-  `GHDL` or `VHDL` to read :ref:`USING:QuickStart` first.
-
 TBC


### PR DESCRIPTION
A reference to the main docs (ghdl.rtfd.io) is added to the home. At the same time, redundant notes from VHPIDIRECT/Examples and VPI/Examples are move to the home as an introduction to this docs.