### PR TITLE
vhpidirect: update 'shared/shghdl'

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -4,7 +4,7 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: build doc
       run: ./doc/make.sh
     - name: 'publish site to gh-pages'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,6 @@ jobs:
             shared/shghdl,
           ]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - run: docker pull $DOCKER_IMAGE
     - run: docker run --rm -tv $(pwd):/src $DOCKER_IMAGE /src/vhpidirect/${{ matrix.task}}/run.sh

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -134,10 +134,11 @@ intersphinx_mapping = {
 
 # -- Sphinx.Ext.ExtLinks --------------------------------------------------
 extlinks = {
-   'wikipedia': ('https://en.wikipedia.org/wiki/%s', None),
-   'ghdlsharp': ('https://github.com/ghdl/ghdl/issues/%s', '#'),
-   'ghdlissue': ('https://github.com/ghdl/ghdl/issues/%s', 'issue #'),
-   'ghdlpull':  ('https://github.com/ghdl/ghdl/pull/%s', 'pull request #'),
-   'ghdlsrc':   ('https://github.com/ghdl/ghdl/blob/master/src/%s', None),
-   'cosimtree': ('https://github.com/ghdl/ghdl-cosim/blob/master/%s', None),
+   'wikipedia':  ('https://en.wikipedia.org/wiki/%s', None),
+   'ghdlsharp':  ('https://github.com/ghdl/ghdl/issues/%s', 'ghdl#'),
+   'ghdlissue':  ('https://github.com/ghdl/ghdl/issues/%s', 'issue #'),
+   'ghdlpull':   ('https://github.com/ghdl/ghdl/pull/%s', 'pull request #'),
+   'ghdlsrc':    ('https://github.com/ghdl/ghdl/blob/master/src/%s', None),
+   'cosimsharp': ('https://github.com/ghdl/ghdl-cosim/issues/%s', 'ghdl-cosim#'),
+   'cosimtree':  ('https://github.com/ghdl/ghdl-cosim/blob/master/%s', None),
 }

--- a/doc/vhpidirect/dynamic.rst
+++ b/doc/vhpidirect/dynamic.rst
@@ -29,7 +29,7 @@ Generating shared libraries
 
 There are three possibilities to elaborate simulation models as shared libraries, instead of executable binaries:
 
-* ``ghdl -e -shared -Wl,-Wl,-u,ghdl_main [options...] primary_unit [secondary_unit]``
+* ``ghdl -e -shared [options...] primary_unit [secondary_unit]``
 
 * ``ghdl -e -Wl,-shared -Wl,-Wl,--version-script=./file.ver -Wl,-Wl,-u,ghdl_main [options...] primary_unit [secondary_unit]``
 

--- a/doc/vhpidirect/dynamic.rst
+++ b/doc/vhpidirect/dynamic.rst
@@ -19,17 +19,55 @@ In order to do so, provide the path and name of the shared library where the res
 
   attribute foreign of get_rand: function is "VHPIDIRECT ./getrand.so get_rand";
 
+.. _COSIM:VHPIDIRECT:Dynamic:generating_shared_libraries:
+
+Generating shared libraries
+===========================
+
+.. TIP::
+  Ensure reading and understanding :ref:`COSIM:VHPIDIRECT:Linking` before this one.
+
+There are three possibilities to elaborate simulation models as shared libraries, instead of executable binaries:
+
+* ``ghdl -e -shared -Wl,-Wl,-u,ghdl_main [options...] primary_unit [secondary_unit]``
+
+* ``ghdl -e -Wl,-shared -Wl,-Wl,--version-script=./file.ver -Wl,-Wl,-u,ghdl_main [options...] primary_unit [secondary_unit]``
+
+* ``gcc -shared -Wl,`ghdl --list-link tb` -Wl,--version-script=./file.ver -Wl,-u,ghdl_main``
+
+The only difference between the two later procedures is the entrypoint (GHDL or GCC). Preference depends on the additional options that users need to provide. The main difference with the former is that it will make all symbols visible in the resulting shared library. In the other two procedures, visible symbols will be the ones defined in the default ``grt.ver`` added by GHDL and the ``file.ver`` provided by the user. Note that ``file.ver`` must include ``ghdl_main`` and any other added by the user. See example :ref:`COSIM:VHPIDIRECT:Examples:shared:shghdl` and :cosimsharp:`2`.
+
+.. HINT::
+  When GHDL is configured with ``--default-pic`` explicitly, it uses it implicitly when executing any :option:`-a`, :option:`-e` or :option:`-r` command. Hence, it is not required to provide these arguments (fPIC/PIE) to GHDL. However, these might need to be provided when building C sources with GCC. Otherwise linker errors such as the following are produced:
+
+  .. code-block::
+
+    relocation R_X86_64_PC32 against symbol * can not be used when making a shared object; recompile with -fPIC
+
+.. HINT::
+  For further details regarding how to call ``ghdl_main`` see :ref:`Starting_a_simulation_from_a_foreign_program`.
+
+.. NOTE::
+  Alternatively, if the shared library is built with :option:`--bind` and :option:`--list-link`, the output from the later can be filtered with tools such as ``sed`` in order to remove the default version script (accomplished in :ghdlsharp:`640`), and make all symbols visible by default. However, this procedure is only recommended in edge cases where other solutions don't fit.
+
 .. _COSIM:VHPIDIRECT:Dynamic:loading_a_simulation:
 
 Loading a simulation
 ====================
+
+.. ATTENTION::
+  By default, GHDL uses ``grt.ver`` to limit which symbols are exposed in the generated artifacts, and ``ghdl_main`` is not included. See :ref:`COSIM:VHPIDIRECT:Dynamic:generating_shared_libraries` for guidelines to generate shared objects with visible or filtered symbols.
 
 In order to generate a position independent executable (PIE), be it an executable binary
 or a shared library, GHDL must be built with config option ``--default-pic``. This will ensure
 that all the libraries and sources analyzed by GHDL generate position independent code (PIC).
 
 PIE binaries can be loaded and executed from any language that supports C-alike signatures and types
-(C, C++, golang, Python, Rust, etc.). For example, in Python:
+(C, C++, golang, Python, Rust, etc.). This allows seamless co-simulation using concurrent/parallel execution features available in each language:
+pthreads, goroutines/gochannels, multiprocessing/queues, etc. Moreover, it provides a mechanism to execute multiple
+GHDL simulations in parallel.
+
+For example, in Python:
 
 .. code-block:: Python
 
@@ -51,15 +89,10 @@ PIE binaries can be loaded and executed from any language that supports C-alike 
   # On Windows
   #_ctypes.FreeLibrary(gbin._handle)
 
-This allows seamless co-simulation using concurrent/parallel execution features available in each language:
-pthreads, goroutines/gochannels, multiprocessing/queues, etc. Moreover, it provides a mechanism to execute multiple
-GHDL simulations in parallel.
+See a complete example written in C in :ref:`COSIM:VHPIDIRECT:Examples:shared:shghdl`.
 
 .. TIP::
-  As explained in :ref:`Starting_a_simulation_from_a_foreign_program`, ``ghdl_main`` must be called once, since reseting/restarting the simulation runtime is not supported yet (see :ghdlsharp:`1184`). When it is loaded dynamically, this means that the binary file/library needs to be unloaded from memory and loaded again.
-
-.. ATTENTION::
-  By default, GHDL uses ``grt.ver`` to limit which symbols are exposed in the generated binary, and ``ghdl_main`` is not included. Hence, the version script needs to be removed, or a complementary script needs to be provided. Otherwise, it will not be possible to find the function easily. See :option:`--list-link` for further info.
+  As explained in :ref:`Starting_a_simulation_from_a_foreign_program`, ``ghdl_main`` must be called once, since reseting/restarting the simulation runtime is not supported yet (see :ghdlsharp:`1184`). When it is loaded dynamically, this means that the binary file/library needs to be unloaded from memory and loaded again (as in :ref:`COSIM:VHPIDIRECT:Examples:shared:shghdl`).
 
 .. TIP::
   See :ghdlsharp:`803` for details about expected differences in the exit codes, depending on the version of the VHDL standard that is used.

--- a/doc/vhpidirect/examples/shared.rst
+++ b/doc/vhpidirect/examples/shared.rst
@@ -36,29 +36,12 @@ This example tests whether symbol ``ghdl_main`` is visible in the shared librari
 
 This example is complementary to :ref:`COSIM:VHPIDIRECT:Examples:shared:shlib`, since the VHDL simulation is built as a shared library, which is then loaded from a main C application (as in :ref:`COSIM:VHPIDIRECT:Examples:shared:dlopen`).
 
-When ``main`` is executed, the shared libray is loaded, symbol ``ghdl_main`` is searched for, and it is executed. Unfortunately, GHL does not make ``ghdl_main`` visible by default. Hence, if a simulation model is to be loaded dynamically, visibility needs to be tweaked. This is also true for any additional function that is described in the C sources that are linked to the simulation model.
+When ``main`` is executed:
 
-* It is possible to force a symbol to be added with ``-Wl,-Wl,-u,ghdl_main``.
+* The shared libray is loaded, symbol ``print_something`` is searched for, and it is executed.
+* Symbol ``ghdl_main`` is searched for, and it is executed three times. Unfortunately, GHDL does not currently support reseting/restarting the simulation runtime. Hence, in this example the shared library is unloaded and loaded again before calling ``ghdl_main`` after the first time.
 
-* If the shared library is built with :option:`-e`, option ``-Wl,-Wl,--version-script=file.ver`` can be used, where ``file.ver`` is an additional custom version file such as:
+See :ref:`Generating_shared_libraries` for further details with regard to the visibility of symbols in the shared libraries.
 
-.. code-block:: C
-
-  VHPIDIRECT {
-    global:
-      ghdl_main;
-    local:
-      *;
-  };
-
-* [**EXPERIMENTAL** :ghdlsharp:`1184`] Alternatively, :option:`-shared` removes the version script.
-.. * [**EXPERIMENTAL** :ghdlsharp:`1184`] As of commit `095190f <https://github.com/ghdl/ghdl/commit/095190fbeeb05c746275947167dcbef5a22f7df5>`_, elaboration flag :option:`-shared` replaces the :option:`--version-script` option. It causes elaboration to produce a shared object file named after the primary entity. Exposure of the GHDL symbols is still needed.
-
-* If the shared library is built with :option:`--bind` and :option:`--list-link`, the output from the later can be filtered with tools such as ``sed`` in order to remove the default version script (accomplished in :ghdlsharp:`640`), and make all symbols visible by default. It is also possible to pass an additional script. See description of :option:`--list-link` for further details.
-
-.. HINT::
-  When GHDL is configured with ``--default-pic`` explicitly, it uses it implicitly when executing any :option:`-a`, :option:`-e` or :option:`-r` command. Hence, it is not required to provide these arguments (fPIC/PIE) to GHDL. However, these might need to be provided when building C sources with GCC. Otherwise linker errors such as the following are produced:
-
-  .. code-block::
-
-    relocation R_X86_64_PC32 against symbol * can not be used when making a shared object; recompile with -fPIC
+.. NOTE::
+  On GNU/linux, both executable binaries and shared libraries use the ELF format. As a result, although hackish, it is possible to load an executable binary dynamically, i.e. without using any of the ``shared`` options explained in :ref:`Generating_shared_libraries`. In this example, this case is also tested. However, this is not suggested at all, since it won't work on all platforms.

--- a/doc/vhpidirect/linking.rst
+++ b/doc/vhpidirect/linking.rst
@@ -22,9 +22,9 @@ library.
 Note the :file:`c` library is always linked with an executable.
 
 .. HINT::
-  The process for personal code is the same, provided the code is compiled to an object file.
-  Analysis must be made of the HDL files, then elaboration with ``-e -Wl,personal.o [options...] primary_unit [secondary_unit]`` as arguments.
-  Additional object files are flagged as separate ``-Wl,*`` arguments. The elaboration step will compile the executable with the custom resources.
+  The process for personal code is the same, provided the code is provided as a C source or compiled to an object file.
+  Analysis must be made of the HDL files, then elaboration with ``-e -Wl,personal.c [options...] primary_unit [secondary_unit]`` as arguments.
+  Additional C or object files are flagged as separate ``-Wl,*`` arguments. The elaboration step will compile the executable with the custom resources.
   Further reading (particularly about the backend particularities) is at :ref:`Elaboration:command` and :ref:`Run:command`.
 
 .. _Linking_with_Ada:

--- a/vhpidirect/shared/shghdl/main.c
+++ b/vhpidirect/shared/shghdl/main.c
@@ -4,15 +4,27 @@
 
 int main(int argc, void** argv) {
 
+  void* h = dlopen("./tb.so", RTLD_LAZY);
+  if (!h){
+    fprintf(stderr, "%s\n", dlerror());
+    exit(1);
+  }
+
+
+  typedef int print_t(char* str);
+
+  print_t* print_something = (print_t*)dlsym(h, "print_something");
+  if (!print_something){
+    fprintf(stderr, "%s\n", dlerror());
+    exit(2);
+  }
+
+  print_something("Hello Something!");
+
+
   typedef int main_t(int, void**);
 
   for (size_t i = 0; i < 3; i++) {
-
-    void* h = dlopen("./tb.so", RTLD_LAZY);
-    if (!h){
-      fprintf(stderr, "%s\n", dlerror());
-      exit(1);
-    }
 
     main_t* ghdl_main = (main_t*)dlsym(h, "ghdl_main");
     if (!ghdl_main){
@@ -23,6 +35,14 @@ int main(int argc, void** argv) {
     printf("ghdl_main return: %d\n", ghdl_main(argc, argv));
 
     dlclose(h);
+
+    if (i<2) {
+      h = dlopen("./tb.so", RTLD_LAZY);
+      if (!h){
+        fprintf(stderr, "%s\n", dlerror());
+        exit(1);
+      }
+    }
 
   }
 

--- a/vhpidirect/shared/shghdl/run.sh
+++ b/vhpidirect/shared/shghdl/run.sh
@@ -17,7 +17,7 @@ ghdl -e -Wl,test.c -Wl,-Wl,--version-script=./test.ver -o tb.so tb
 ./main
 
 echo "> Build and execute [GHDL -shared]"
-ghdl -e -Wl,test.c -shared -Wl,-Wl,-u,ghdl_main -o tb.so tb
+ghdl -e -Wl,test.c -shared -o tb.so tb
 ./main
 
 echo "> Build and execute [GHDL -Wl,-shared]"

--- a/vhpidirect/shared/shghdl/run.sh
+++ b/vhpidirect/shared/shghdl/run.sh
@@ -4,14 +4,29 @@ set -e
 
 cd $(dirname "$0")
 
-echo "Analyze tb.vhd"
+echo "> Analyze tb.vhd"
 ghdl -a tb.vhd
 
-echo "Build main.c"
+echo "> Build main.c"
 gcc main.c -o main -ldl
 
-echo "Build tb.so [GHDL]"
-ghdl -e -Wl,-Wl,--version-script=../../vhpidirect.ver -o tb.so tb
+#---
 
-echo "Execute main"
+echo "> Build and execute [GHDL]"
+ghdl -e -Wl,test.c -Wl,-Wl,--version-script=./test.ver -o tb.so tb
+./main
+
+echo "> Build and execute [GHDL -shared]"
+ghdl -e -Wl,test.c -shared -Wl,-Wl,-u,ghdl_main -o tb.so tb
+./main
+
+echo "> Build and execute [GHDL -Wl,-shared]"
+ghdl -e -Wl,test.c -Wl,-shared -Wl,-Wl,--version-script=./test.ver -Wl,-Wl,-u,ghdl_main -o tb.so tb
+./main
+
+echo "> Bind tb"
+ghdl --bind tb
+
+echo "> Build and execute [GCC -shared]"
+gcc test.c -shared -Wl,`ghdl --list-link tb` -Wl,--version-script=./test.ver -Wl,-u,ghdl_main -o tb.so
 ./main

--- a/vhpidirect/shared/shghdl/test.c
+++ b/vhpidirect/shared/shghdl/test.c
@@ -1,0 +1,5 @@
+#include <stdio.h>
+
+void print_something(char* str) {
+  printf("%s\n", str);
+}

--- a/vhpidirect/shared/shghdl/test.ver
+++ b/vhpidirect/shared/shghdl/test.ver
@@ -1,0 +1,7 @@
+VHPIDIRECT {
+  global:
+ghdl_main;
+print_something;
+  local:
+        *;
+};


### PR DESCRIPTION
Fix #2

As discussed in #2, this PR documents different approaches to generate simulation models as shared libraries, to be dynamically loaded and executed from foreign languages/applications.

@RocketRoss, I guess this will make it easier for new users (as you in ghdl/ghdl#1184) to understand how to generate shared libraries to execute simulations multiple times from foreign languages. Would you mind reviewing this PR?

<strike>NOTE: I did not remove `-Wl,-Wl,-u,ghdl_main` from `ghdl -e -shared` yet. We can either keep this PR open until GHDL is updated, or we can merge this before and update the example/docs later.</strike> The failure of shared/shghdl is expected until the docker image is updated.