### PR TITLE
vhpidirect: add 'cinterface/grt'

### DIFF
--- a/doc/vhpidirect/examples/grt.rst
+++ b/doc/vhpidirect/examples/grt.rst
@@ -1,0 +1,17 @@
+.. program:: ghdl
+.. _COSIM:VHPIDIRECT:Examples:grt:
+
+GRT
+###
+
+.. _COSIM:VHPIDIRECT:Examples:grt:step:
+
+:cosimtree:`step <vhpidirect/grt/step>`
+***************************************
+
+As explained in :ref:`COSIM:VHPIDIRECT:Wrapping:Step`, GHDL allows executing simulations step by step when wrapped in a
+foreign language. This is a minimal showcase.
+
+The testbench in this example is a single process that prints a message 10 times, every ``10 ns``; then it waits indefinitely.
+The wrapper uses a ``do {} while`` loop for printing the return code of each step. If/when the return code is ``>2``, the
+simulation is either finished or stopped, so the program exits.

--- a/doc/vhpidirect/examples/index.rst
+++ b/doc/vhpidirect/examples/index.rst
@@ -6,6 +6,7 @@ Examples
 .. toctree::
 
    quickstart
+   grt
    shared
    arrays
    vffi_user

--- a/doc/vhpidirect/wrapping.rst
+++ b/doc/vhpidirect/wrapping.rst
@@ -4,11 +4,27 @@
 
 .. _Starting_a_simulation_from_a_foreign_program:
 
-Wrapping a simulation (ghdl_main)
-=================================
+Wrapping a simulation
+#####################
 
-You may run your design from an external program. You just have to call
-the ``ghdl_main`` function which can be defined:
+By default, GHDL generates an internal ``main`` function, which is the entrypoint to executable binaries/simulations. However,
+simulation can be optionally executed from external programs, by declaring given functions as externally defined resources. Should
+an alternative ``main`` function be defined, that will be used by the executable, instead of the one from GHDL.
+
+Wrapping the simulation allows dynamically generating test data, and/or manipulating CLI arguments.
+
+.. ATTENTION::
+  Shared libraries should not contain a ``main`` symbol, but explicitly named entrypoints. When :ref:`COSIM:VHPIDIRECT:Dynamic:generating_shared_libraries`
+  or :ref:`COSIM:VHPIDIRECT:Dynamic:loading_a_simulation`, wrapping ``ghdl_main`` is required.
+
+Single function exection (ghdl_main)
+====================================
+
+Function ``ghdl_main`` allows executing the simulation until termination. When called, GRT takes control and drives the simulation,
+without intervention from the wrapper. However, if VHPIDIRECT or VPI functions/callbacks were registered, those are triggered
+at the corresponding simulation time.
+
+In your foreign sources, define the external prototype of ``ghdl_main`` as follows:
 
 in C:
 
@@ -27,12 +43,40 @@ in Ada:
   pragma import (C, Ghdl_Main, "ghdl_main");
 
 .. TIP::
-  Don't forget to list the object file(s) of this entry point and other foreign sources, as per :ref:`Linking_with_foreign_object_files`.
+  Don't forget to list the object file(s) of this entry point and other foreign sources, as per
+  :ref:`Linking_with_foreign_object_files`.
 
 .. ATTENTION::
-  The ``ghdl_main`` function must be called once, since reseting/restarting the simulation runtime is not supported yet. A workaround is to build the simulation as a shared object and load the ``ghdl_main`` symbol from it (see :ref:`COSIM:VHPIDIRECT:Examples:shared:shghdl`).
+  The ``ghdl_main`` function must be called once, since reseting/restarting the simulation runtime is not supported yet. A
+  workaround is to build the simulation as a shared object and load the ``ghdl_main`` symbol from it (see :ref:`COSIM:VHPIDIRECT:Examples:shared:shghdl`).
 
 .. HINT::
-  Immitating the run time flags, such as ``-gDEPTH=12`` from :option:`-gGENERIC`, requires the ``argv`` to have the executable's path at index 0, effectively shifting all other indicies along by 1. This can be taken from the 0 index of the ``argv`` passed to ``main()``, or (not suggested, despite a lack of consequences) left empty/null.
+  Immitating the run time flags, such as ``-gDEPTH=12`` from :option:`-gGENERIC`, requires the ``argv`` to have the
+  executable's path at index 0, effectively shifting all other indicies along by 1. This can be taken from the 0 index of the
+  ``argv`` passed to ``main()``, or (not suggested, despite a lack of consequences) left empty/null.
 
-  Since ``ghdl_main`` is the entrypoint to the design (GRT runtime), the supported CLI options are the ones shown in :ref:`USING:Simulation`. Options for analysis/elaboration are not required and will NOT work. See :option:`-r`.
+  Since ``ghdl_main`` is the entrypoint to the design (the simulation kernel/runtime named GRT), the supported CLI options
+  are the ones shown in :ref:`USING:Simulation`. Options for analysis/elaboration are not required and will NOT work. See :option:`-r`.
+
+.. _COSIM:VHPIDIRECT:Wrapping:Step:
+
+Step by step execution
+======================
+
+For finer grained control of the simulation steps, a set of lower level functions can be used instead of ``ghdl_main``.
+Those are provided in :cosimtree:`grt.h <vhpidirect/grt/grt.h>`. After initializing GRT, providing arguments and initializing
+the simulation, a loop allows checking the return value of each step:
+
+.. code-block:: C
+
+  // 0: delta cycle
+  // 1: non-delta cycle
+  // 2: stop
+  // 3: finished
+  // 4: stop-time reached
+  // 5: stop-delta reached
+  int ecode;
+  do {
+    ecode = __ghdl_simulation_step ();
+    printf("ecode: %d\n", ecode);
+  } while (ecode<3);

--- a/test.py
+++ b/test.py
@@ -43,6 +43,9 @@ class TestExamples(TestCase):
     def _py(self, args):
         check_call([executable] + args, stderr=STDOUT)
 
+    #
+    # QuickStart
+    #
 
     def test_vhpidirect_quickstart_random(self):
         self._sh([str(self.vhpidirect / 'quickstart' / 'random' / 'run.sh')])
@@ -92,6 +95,9 @@ class TestExamples(TestCase):
     def test_vhpidirect_quickstart_cli_fcngen(self):
         self._sh([str(self.vhpidirect / 'quickstart' / 'cli' / 'fcngen' / 'run.sh')])
 
+    #
+    # Shared
+    #
 
     def test_vhpidirect_shared_shlib(self):
         self._sh([str(self.vhpidirect / 'shared' / 'shlib' / 'run.sh')])
@@ -123,6 +129,9 @@ class TestExamples(TestCase):
     def test_vhpidirect_shared_pycb(self):
         self._sh([str(self.vhpidirect / 'shared' / 'pycb' / 'run.sh')])
 
+    #
+    # Arrays
+    #
 
     def test_vhpidirect_arrays_intvector(self):
         self._sh([str(self.vhpidirect / 'arrays' / 'intvector' / 'run.sh')])
@@ -147,6 +156,9 @@ class TestExamples(TestCase):
     def test_vhpidirect_arrays_matrices_framebuffer(self):
         self._sh([str(self.vhpidirect / 'arrays' / 'matrices' / 'framebuffer' / 'run.sh')])
 
+    #
+    # VFFI/VDPI
+    #
 
     @pytest.mark.skipif(
         isWin and ('MINGW_PREFIX' not in environ),
@@ -164,6 +176,16 @@ class TestExamples(TestCase):
         self._py([str(self.vhpidirect / 'vffi_user' / 'xyce' / 'run_minimal.py'), '-v', '--clean', '--xunit-xml=%s' % str(self.report_file), '--output-path=%s' % str(self.output_path)])
         self._py([str(self.vhpidirect / 'vffi_user' / 'xyce' / 'run.py'), '-v', '--clean', '--xunit-xml=%s' % str(self.report_file), '--output-path=%s' % str(self.output_path)])
 
+    #
+    # GRT
+    #
+
+    def test_vhpidirect_grt_step(self):
+        self._sh([str(self.vhpidirect / 'grt' / 'step' / 'run.sh')])
+
+    #
+    # VPI
+    #
 
     def test_vpi_quickstart(self):
         self._sh([str(self.vpi / 'quickstart' / 'run.sh')])

--- a/vhpidirect/grt/grt.h
+++ b/vhpidirect/grt/grt.h
@@ -1,0 +1,12 @@
+void grt_init (void);
+int grt_main_options (const char *progname, int argc, const char * const argv[]);
+int grt_main_elab (void);
+void __ghdl_simulation_init (void);
+int __ghdl_simulation_step (void);
+//  Return value:
+//  0: delta cycle
+//  1: non-delta cycle
+//  2: stop
+//  3: finished
+//  4: stop-time reached
+//  5: stop-delta reached

--- a/vhpidirect/grt/step/main.c
+++ b/vhpidirect/grt/step/main.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <grt.h>
+
+int main(int argc, void** argv) {
+  grt_init ();
+  grt_main_options (argv[0], argc, (const char * const*)argv);
+  grt_main_elab ();
+  __ghdl_simulation_init ();
+  int ecode;
+  do {
+    ecode = __ghdl_simulation_step ();
+    printf("ecode: %d\n", ecode);
+  } while (ecode<3);
+  return 0;
+}

--- a/vhpidirect/grt/step/run.sh
+++ b/vhpidirect/grt/step/run.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd $(dirname "$0")
+
+echo "> Analyze tb.vhd"
+ghdl -a tb.vhd
+
+echo "> Build tb (with ghdl.h and main.c)"
+ghdl -e -Wl,-I.. -Wl,main.c tb
+
+echo "> Execute tb"
+./tb

--- a/vhpidirect/grt/step/tb.vhd
+++ b/vhpidirect/grt/step/tb.vhd
@@ -1,0 +1,16 @@
+entity tb is
+end entity;
+
+architecture arch of tb is
+begin
+  process
+    variable cnt: natural := 0;
+  begin
+    wait for 10 ns;
+    report "Hello grt/step! [" & integer'image(cnt) & "]";
+    cnt := cnt + 1;
+    if cnt = 10 then
+      wait;
+    end if;
+  end process;
+end;


### PR DESCRIPTION
This is a proof of concept to implement step-by-step coexecution from C; that is, to support `ghdl_runfor`, `ghdl_rununtil` and `ghdl_restart`.

Replying to myself in https://github.com/ghdl/ghdl/issues/1053#issuecomment-612569556, it is possible to replace `ghdl_main` with `grt_init`, `grt_main_options`, `grt_main_elab`, `__ghdl_simulation_init` and `__ghdl_simulation_step`. However, it seems that all the simulation is executed in the first and single call to the later.