### PR TITLE
ci: use GHA log groups

### DIFF
--- a/test.py
+++ b/test.py
@@ -2,10 +2,11 @@
 Verify that all example run scripts work correctly
 """
 
+import sys
 from sys import executable, platform
 from os import environ
 from pathlib import Path
-from subprocess import check_call
+from subprocess import check_call, STDOUT
 import unittest
 import pytest
 
@@ -21,69 +22,102 @@ class TestExamples(unittest.TestCase):
         self.vhpidirect = self.root / 'vhpidirect'
         self.vpi = self.root / 'vpi'
 
+        print('\n##[group]Log')
+        sys.stdout.flush()
+
+    def tearDown(self):
+        print('##[endgroup]')
+        sys.stdout.flush()
+
+    def _sh(self, args):
+        check_call(self.shell + args, shell=True, stderr=STDOUT)
+
+    def _py(self, args):
+        check_call([executable] + args, shell=True, stderr=STDOUT)
+
+
     def test_vhpidirect_quickstart_random(self):
-        check_call(self.shell + [str(self.vhpidirect / 'quickstart' / 'random' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'quickstart' / 'random' / 'run.sh')])
+
 
     def test_vhpidirect_quickstart_math(self):
-        check_call(self.shell + [str(self.vhpidirect / 'quickstart' / 'math' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'quickstart' / 'math' / 'run.sh')])
+
 
     def test_vhpidirect_quickstart_customc(self):
-        check_call(self.shell + [str(self.vhpidirect / 'quickstart' / 'customc' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'quickstart' / 'customc' / 'run.sh')])
+
 
     def test_vhpidirect_quickstart_wrapping_basic(self):
-        check_call(self.shell + [str(self.vhpidirect / 'quickstart' / 'wrapping' / 'basic' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'quickstart' / 'wrapping' / 'basic' / 'run.sh')])
+
 
     def test_vhpidirect_quickstart_wrapping_time(self):
-        check_call(self.shell + [str(self.vhpidirect / 'quickstart' / 'wrapping' / 'time' / 'run.sh')], shell=True)
+        self._sh([
+            str(self.vhpidirect / 'quickstart' / 'wrapping' / 'time' / 'run.sh'),
+            'ada' if platform != 'win32' else ''
+        ])
+
 
     @unittest.skipUnless(
         platform != 'win32',
         "win: needs investigation, output of list-link seems to have wrong path format",
     )
     def test_vhpidirect_quickstart_linking_bind(self):
-        check_call(self.shell + [str(self.vhpidirect / 'quickstart' / 'linking' / 'bind' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'quickstart' / 'linking' / 'bind' / 'run.sh')])
+
 
     def test_vhpidirect_quickstart_package(self):
-        check_call(self.shell + [str(self.vhpidirect / 'quickstart' / 'package' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'quickstart' / 'package' / 'run.sh')])
+
 
     def test_vhpidirect_quickstart_sharedvar(self):
-        check_call(self.shell + [str(self.vhpidirect / 'quickstart' / 'sharedvar' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'quickstart' / 'sharedvar' / 'run.sh')])
+
 
     def test_vhpidirect_shared_shlib(self):
-        check_call(self.shell + [str(self.vhpidirect / 'shared' / 'shlib' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'shared' / 'shlib' / 'run.sh')])
+
 
     @unittest.skipUnless(
         platform != 'win32',
         "win: dlfcn.h is not available on win",
     )
     def test_vhpidirect_shared_dlopen(self):
-        check_call(self.shell + [str(self.vhpidirect / 'shared' / 'dlopen' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'shared' / 'dlopen' / 'run.sh')])
+
 
     @unittest.skipUnless(
         platform != 'win32',
         "win: dlfcn.h is not available on win",
     )
     def test_vhpidirect_shared_shghdl(self):
-        check_call(self.shell + [str(self.vhpidirect / 'shared' / 'shghdl' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'shared' / 'shghdl' / 'run.sh')])
+
 
     def test_vhpidirect_arrays_intvector(self):
-        check_call(self.shell + [str(self.vhpidirect / 'arrays' / 'intvector' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'arrays' / 'intvector' / 'run.sh')])
+
 
     def test_vhpidirect_arrays_logicvector(self):
-        check_call(self.shell + [str(self.vhpidirect / 'arrays' / 'logicvector' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'arrays' / 'logicvector' / 'run.sh')])
+
 
     def test_vhpidirect_arrays_matrices(self):
-        check_call(self.shell + [str(self.vhpidirect / 'arrays' / 'matrices' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'arrays' / 'matrices' / 'run.sh')])
+
 
     def test_vhpidirect_arrays_matrices_vunit_axis_vcs(self):
-        check_call([executable, str(self.vhpidirect / 'arrays' / 'matrices' / 'vunit_axis_vcs' / 'run.py')], shell=True)
+        self._py([str(self.vhpidirect / 'arrays' / 'matrices' / 'vunit_axis_vcs' / 'run.py'), '-v'])
+
 
     @unittest.skipUnless(
         platform != 'win32',
         "win: needs ImageMagick's 'convert'",
     )
     def test_vhpidirect_arrays_matrices_framebuffer(self):
-        check_call(self.shell + [str(self.vhpidirect / 'arrays' / 'matrices' / 'framebuffer' / 'run.sh')], shell=True)
+        self._sh([str(self.vhpidirect / 'arrays' / 'matrices' / 'framebuffer' / 'run.sh')])
+
 
     def test_vpi_quickstart(self):
-        check_call(self.shell + [str(self.vpi / 'quickstart' / 'run.sh')], shell=True)
+        self._sh([str(self.vpi / 'quickstart' / 'run.sh')])

--- a/vhpidirect/quickstart/wrapping/time/run.sh
+++ b/vhpidirect/quickstart/wrapping/time/run.sh
@@ -13,7 +13,7 @@ ghdl -e -Wl,main.c tb
 echo "Execute tb"
 ./tb
 
-if [ $(which gnatmake) ]; then
+if which gnatmake && [ "x$1" = "xada" ]; then
   echo "Bind tb"
   ghdl --bind tb
 


### PR DESCRIPTION
`test.py` is modified to wrap the output of each test/example in a collapsible group.

At the same, time, `gnatmake` is now available on win-setup, but the Ada subexample of `vhpidirect/quickstart/wrapping/time` does not work because `win: needs investigation, output of list-link seems to have wrong path format`. A check is added to avoid executing the failing subexample on windows.