### PR TITLE
vpi: fix quickstart example for mcode build; add ref to CoCoTb-pygame demo

### DIFF
--- a/doc/vpi/examples/other.rst
+++ b/doc/vpi/examples/other.rst
@@ -25,3 +25,14 @@ GTKWave, as in a traditional workflow. Available peripherals are 7 segment displ
 .. image:: https://gitlab.ensta-bretagne.fr/bollenth/ghdl-vpi-virtual-board/-/raw/master/images/screenshot_main_window.png
    :align: center
    :target: https://gitlab.ensta-bretagne.fr/bollenth/ghdl-vpi-virtual-board
+
+GHDL-Cocotb Interactive Simulation
+==================================
+
+`GHDL-Cocotb interactive simulation <https://github.com/chuckb/ghdl-interactive-sim>`__ is a VPI application that
+demonstrates how to create a Python-based interactive simulation. Like GHDL VPI virtual board, it provides a testbench and a matching GUI for testing
+a design, instead of examining waveforms. Unlike GHDL VPI virtual board, using Python makes interactive GUI creation an easier task.
+
+.. image:: https://github.com/chuckb/ghdl-interactive-sim/blob/fb7e1390630f67be2e8599e26ac7c65aa6958ed9/test/images/screen_shot.png
+   :align: center
+   :target: https://github.com/chuckb/ghdl-interactive-sim

--- a/doc/vpi/examples/other.rst
+++ b/doc/vpi/examples/other.rst
@@ -26,16 +26,20 @@ GTKWave, as in a traditional workflow. Available peripherals are 7 segment displ
    :align: center
    :target: https://gitlab.ensta-bretagne.fr/bollenth/ghdl-vpi-virtual-board
 
+|br|
+
 GHDL-Cocotb GUI Simulation
 ==========================
 
-`GHDL-Cocotb GUI Simulation <https://blog.chuckstechtalk.com/software/2021/12/27/interactive-vhdl-testbench.html>`__ is a VPI application that
-demonstrates how to create a Python-based interactive GUI simulation using ghdl, cocotb, and pygame. It provides a
-testbench and a matching GUI with I/O peripherals for testing a design, instead of examining waveforms. While 
-similar to the `GHDL VPI virtual board <https://gitlab.ensta-bretagne.fr/bollenth/ghdl-vpi-virtual-board>`__ example, using
-`cocotb <https://github.com/cocotb/cocotb>`__ and `pygame <https://www.pygame.org>__` makes interactive GUI creation more dynamic
-than using a compiled language (such as C++).
+`blog.chuckstechtalk.com: An Interactive VHDL Testbench Using GHDL, Python, and Cocotb <https://blog.chuckstechtalk.com/software/2021/12/27/interactive-vhdl-testbench.html>`__
+is a VPI application that demonstrates how to create a Python-based interactive GUI simulation using ghdl, cocotb, and
+pygame.
+It provides a testbench and a matching GUI with I/O peripherals for testing a design, instead of examining waveforms.
+While similar to the `GHDL VPI virtual board <https://gitlab.ensta-bretagne.fr/bollenth/ghdl-vpi-virtual-board>`__
+example, using `cocotb <https://github.com/cocotb/cocotb>`__ and `pygame <https://www.pygame.org>`__ makes interactive
+GUI creation more dynamic than using a compiled language (such as C++).
 
 .. image:: https://github.com/chuckb/ghdl-interactive-sim/raw/8a466215dd18c6c809dd96f8d03fa53cad8417c2/test/images/screen_shot.png
    :align: center
+   :height: 400px
    :target: https://github.com/chuckb/ghdl-interactive-sim

--- a/doc/vpi/examples/other.rst
+++ b/doc/vpi/examples/other.rst
@@ -26,12 +26,15 @@ GTKWave, as in a traditional workflow. Available peripherals are 7 segment displ
    :align: center
    :target: https://gitlab.ensta-bretagne.fr/bollenth/ghdl-vpi-virtual-board
 
-GHDL-Cocotb Interactive Simulation
-==================================
+GHDL-Cocotb GUI Simulation
+==========================
 
-`GHDL-Cocotb interactive simulation <https://blog.chuckstechtalk.com/software/2021/12/27/interactive-vhdl-testbench.html>`__ is a VPI application that
-demonstrates how to create a Python-based interactive simulation. Like GHDL VPI virtual board, it provides a testbench and a matching GUI for testing
-a design, instead of examining waveforms. Unlike GHDL VPI virtual board, using Python makes interactive GUI creation an easier task.
+`GHDL-Cocotb GUI Simulation <https://blog.chuckstechtalk.com/software/2021/12/27/interactive-vhdl-testbench.html>`__ is a VPI application that
+demonstrates how to create a Python-based interactive GUI simulation using ghdl, cocotb, and pygame. It provides a
+testbench and a matching GUI with I/O peripherals for testing a design, instead of examining waveforms. While 
+similar to the `GHDL VPI virtual board <https://gitlab.ensta-bretagne.fr/bollenth/ghdl-vpi-virtual-board>`__ example, using
+`cocotb <https://github.com/cocotb/cocotb>`__ and `pygame <https://www.pygame.org>__` makes interactive GUI creation more dynamic
+than using a compiled language (such as C++).
 
 .. image:: https://github.com/chuckb/ghdl-interactive-sim/raw/8a466215dd18c6c809dd96f8d03fa53cad8417c2/test/images/screen_shot.png
    :align: center

--- a/doc/vpi/examples/other.rst
+++ b/doc/vpi/examples/other.rst
@@ -29,10 +29,10 @@ GTKWave, as in a traditional workflow. Available peripherals are 7 segment displ
 GHDL-Cocotb Interactive Simulation
 ==================================
 
-`GHDL-Cocotb interactive simulation <https://github.com/chuckb/ghdl-interactive-sim>`__ is a VPI application that
+`GHDL-Cocotb interactive simulation <https://blog.chuckstechtalk.com/software/2021/12/27/interactive-vhdl-testbench.html>`__ is a VPI application that
 demonstrates how to create a Python-based interactive simulation. Like GHDL VPI virtual board, it provides a testbench and a matching GUI for testing
 a design, instead of examining waveforms. Unlike GHDL VPI virtual board, using Python makes interactive GUI creation an easier task.
 
-.. image:: https://github.com/chuckb/ghdl-interactive-sim/blob/fb7e1390630f67be2e8599e26ac7c65aa6958ed9/test/images/screen_shot.png
+.. image:: https://github.com/chuckb/ghdl-interactive-sim/raw/8a466215dd18c6c809dd96f8d03fa53cad8417c2/test/images/screen_shot.png
    :align: center
    :target: https://github.com/chuckb/ghdl-interactive-sim

--- a/vpi/quickstart/run.sh
+++ b/vpi/quickstart/run.sh
@@ -22,9 +22,4 @@ if [ "$OS" = "Windows_NT" ]; then
 fi
 
 echo "> Execute tb"
-if [ `ghdl version | grep mcode | wc -l` = "1" ]; then
-  # if ghdl compiled with mcode, tb executable will not exist
-  ghdl -r tb --vpi=./vpi.vpi
-else
-  ./tb --vpi=./vpi.vpi
-fi
+ghdl -r tb --vpi=./vpi.vpi

--- a/vpi/quickstart/run.sh
+++ b/vpi/quickstart/run.sh
@@ -22,4 +22,9 @@ if [ "$OS" = "Windows_NT" ]; then
 fi
 
 echo "> Execute tb"
-./tb --vpi=./vpi.vpi
+if [ `ghdl version | grep mcode | wc -l` = "1" ]; then
+  # if ghdl compiled with mcode, tb executable will not exist
+  ghdl -r tb --vpi=./vpi.vpi
+else
+  ./tb --vpi=./vpi.vpi
+fi


### PR DESCRIPTION
Running on Mac...installed ghdl via homebrew. That binary was build for mcode generation. Thus, this example did not work.